### PR TITLE
Synthesize OCI tenancy names as tags

### DIFF
--- a/OCI-CBF-TABLE.md
+++ b/OCI-CBF-TABLE.md
@@ -1,0 +1,24 @@
+# OCI/CBF Field Mappings
+
+OCI emits both Cost and Usage reports. This tool uses only the Cost reports, as CBF has no fields for usage ("500 MB of this resource", etc). CBF only has fields for the cost of usage, which OCI emits in the cost report, so only that is used.
+
+You can view details of the [OCI Cost Reports schema](https://docs.oracle.com/en-us/iaas/Content/Billing/Concepts/usagereportsoverview.htm#Cost_and_Usage_Reports_Overview__cost_report_schema) on Oracle's documentation site, and the same for [CBF Schema](https://docs.cloudzero.com/docs/anycost-common-bill-format-cbf#data-file-columns) at CloudZero's.
+
+| OCI Cost File Column        | CBF Column                           | Notes                                                                                          |
+| --------------------------- | ------------------------------------ | ---------------------------------------------------------------------------------------------- |
+|                             | lineitem/type                        | Always set to 'Usage'                                                                          |
+| product/description         | lineitem/description                 |                                                                                                |
+| lineitem/intervalUsageStart | time/usage_start                     | Always UTC from Oracle                                                                         |
+| lineitem/intervalUsageStart | time/usage_end                       | Always UTC from Oracle                                                                         |
+| product/resourceId          | resource/id                          |                                                                                                |
+| product/service             | resource/service                     |                                                                                                |
+| lineItem/tenantId           | resource/account                     |                                                                                                |
+| product/region              | resource/region                      |                                                                                                |
+| lineItem/tenantId           | action/account                       |                                                                                                |
+| usage/BilledQuantity        | usage/amount                         |                                                                                                |
+| cost/myCost                 | cost/cost                            |                                                                                                |
+| tags/`<tag_key>`            | resource/tag:`<tag_key>`             | OCI tag keys permit more characters than CBF does. Disallowed CBF characters will be stripped. |
+|                             | resource/tag:oci_tenancy_name        | Synthesized tag                                                                                |
+|                             | resource/tag:oci_compartment_name    | Synthesized tag                                                                                |
+|                             | resource/tag:oci_compartment_id      | Synthesized tag                                                                                |
+|                             | resource/tag:oci_availability_domain | Synthesized tag                                                                                |

--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ For example, cost data files for January will continue to flow into the OCI obje
 
 Additional runs that pick up no new data do not affect accuracy, they merely incur processing cost.
 
+### Output Notes
+
+OCI billing output doesn't necessarily map cleanly to every CBF field. Some special handling of OCI-specific tenancy and account properties are represented as synthesized resource tags. For details, see [OCI/CBF Field Mappings](OCI-CBF-TABLE.md).
+
 ## Contributing
 
 We appreciate feedback and contribution to this repo! Before you get started, please see the following:

--- a/python/anycostoci.py
+++ b/python/anycostoci.py
@@ -189,8 +189,8 @@ def build_anycost_drop_from_oci_files(lookback_months: int,
                         cbf_frame.insert(len(cbf_frame.columns), tag_column, oci_cost.loc[:, c])
 
                 # Synthesized tag for account name
-                cbf_frame.insert(len(cbf_frame.columns), 'resource/tag:tenancy_name', oci_cost.loc[:, 'lineItem/tenantId'])
-                cbf_frame['resource/tag:tenancy_name'] = cbf_frame['resource/tag:tenancy_name'].map(lambda t:__tenancy_name_lookup(t, oci_config))
+                cbf_frame.insert(len(cbf_frame.columns), 'resource/tag:oci_tenancy_name', oci_cost.loc[:, 'lineItem/tenantId'])
+                cbf_frame['resource/tag:oci_tenancy_name'] = cbf_frame['resource/tag:oci_tenancy_name'].map(lambda t:__tenancy_name_lookup(t, oci_config))
 
                 # This section prunes the CBF frames to contain only rows with
                 # usage_start dates within the BDID boundary.

--- a/python/anycostoci.py
+++ b/python/anycostoci.py
@@ -166,8 +166,8 @@ def build_anycost_drop_from_oci_files(lookback_months: int,
                 cbf_frame.insert(0, 'lineitem/id', oci_cost.loc[:, 'lineItem/referenceNo'])
                 # AFAICT all cost types in OCI are 'Usage', with the possible
                 # exception of 'Adjustment's for rows with isCorrection=True.
-                # Depending on how corrections are handled we may not need
-                # to show that.
+                # However, Adjustments just emit the corrected cost, not the 
+                # offset. So we'll just call everything Usage.
                 cbf_frame.insert(1, 'lineitem/type', 'Usage')
                 cbf_frame.insert(2, 'lineitem/description', oci_cost.loc[:, 'product/Description'])
                 cbf_frame.insert(3, 'time/usage_start', oci_cost.loc[:, 'lineItem/intervalUsageStart'])

--- a/python/anycostoci.py
+++ b/python/anycostoci.py
@@ -20,7 +20,7 @@ def __create_or_verify_bdid_folder(start_date: datetime, output_dir: str, drop_i
     first_of_the_month = start_date.replace(day=1)
     # Calculate the last date of that month
     last_date_of_the_month = calendar.monthrange(start_date.year, start_date.month)[1]
-    # Make a datetime for that last date. 
+    # Make a datetime for that last date.
     last_of_the_month = start_date.replace(day=last_date_of_the_month)
     # Add 1 day to get the first of the next month
     first_of_next_month = last_of_the_month + timedelta(days=1)
@@ -46,7 +46,6 @@ def __months_lookback(lookback_months: int) -> dict:
     start_date = datetime.utcnow().date() - dateutil.relativedelta.relativedelta(months=lookback_months)
     start_date = start_date.replace(day=1)
 
-    # end_date = datetime.utcnow().date() - dateutil.relativedelta.relativedelta(months=1)
     last_day_of_the_month = calendar.monthrange(start_date.year, start_date.month)[1]
     end_date = start_date.replace(day=last_day_of_the_month)
 
@@ -55,22 +54,28 @@ def __months_lookback(lookback_months: int) -> dict:
 
 def __tenancy_name_lookup(tenancy_id: str, oci_config) -> str:
     """Look up a tenancy name by ID, caching the result"""
-    # print(f"Entering tenancy name lookup for ID {tenancy_id}")
     tenancy_name = tenancy_id_cache.get(tenancy_id)
     if tenancy_name != None:
-        # print(f"Found tenancy name {tenancy_name}")
+        # print(f"Found cached tenancy name {tenancy_name}")
         return tenancy_name
-    
+
     try:
+        print(f"Tenant ID {tenancy_id} was uncached, making API call...")
+
         oci.config.validate_config(oci_config)
-        iam = oci.identity.IdentityClient(oci_config)
-        # print(f"Tenant ID {tenancy_id} was uncached, making API call...")
-        get_tenancy_response = iam.get_tenancy(tenancy_id)
+        org = oci.tenant_manager_control_plane.OrganizationClient(oci_config)
+
+        # Get the organization OCID of the client
+        get_org_response = org.list_organizations(oci_config['tenancy'])
+        org_ocid = get_org_response.data.items[0].id
+
+        # Get the tenancy given the org OCID and return the name
+        get_tenancy_response = org.get_organization_tenancy(org_ocid, tenancy_id)
         tenancy_name = get_tenancy_response.data.name
         tenancy_id_cache[tenancy_id] = tenancy_name
-        # print(f"Tenant ID {tenancy_id} lookup success, name was {tenancy_name}")
+        print(f"Tenant ID {tenancy_id} lookup success, name was {tenancy_name}")
     except oci.exceptions.ServiceError:
-        # print(f"Tenant ID {tenancy_id} lookup failed, setting empty")
+        print(f"Tenant ID {tenancy_id} lookup failed, setting name to empty string")
         tenancy_name = ""
         tenancy_id_cache[tenancy_id] = tenancy_name
 
@@ -90,7 +95,8 @@ def download_oci_cost_files(lookback_months: int, oci_config, output_dir = '/tmp
     # following month.
     report_end_date = end_date + timedelta(days=3)
 
-    # TODO: the point of pagination is to make repeated calls. Push this paginating into the fetch/comparison loop function
+    # TODO: the point of pagination is to make repeated calls. 
+    # Push this paginating into the fetch/comparison loop function
     report_bucket_objects = oci.pagination.list_call_get_all_results(
                             object_storage.list_objects,
                             'bling',
@@ -117,7 +123,7 @@ def download_oci_cost_files(lookback_months: int, oci_config, output_dir = '/tmp
 
 def build_anycost_drop_from_oci_files(lookback_months: int,
                                       oci_config,
-                                      oci_cost_files_dir = '/tmp/', 
+                                      oci_cost_files_dir = '/tmp/',
                                       output_dir = '/tmp/anycost_drop/') -> slice:
     """Take a directory of gzipped OCI cost reports and build an AnyCost drop out of them.
 
@@ -140,9 +146,9 @@ def build_anycost_drop_from_oci_files(lookback_months: int,
     drop_paths = set()
 
     for root, dirs, cost_files in os.walk(oci_cost_files_dir):
-        # It would be swell if this yielded the files in order. 
+        # It would be swell if this yielded the files in order.
         # The filenames are ordered numbers and we could display progress
-        for cost_file in cost_files: 
+        for cost_file in cost_files:
             if not re.match(".*\.csv\.gz$", cost_file):
                 continue
 
@@ -152,7 +158,7 @@ def build_anycost_drop_from_oci_files(lookback_months: int,
                     oci_cost = pandas.read_csv(f)
                 except pandas.errors.EmptyDataError:
                     print(f"No rows read from file {root}/{cost_file}")
-                    
+
                 # Start building the CBF formatted frame
                 cbf_frame = pandas.DataFrame([])
 
@@ -188,9 +194,29 @@ def build_anycost_drop_from_oci_files(lookback_months: int,
                         tag_column = "resource/tag:" + oci_tag_key_cleaned
                         cbf_frame.insert(len(cbf_frame.columns), tag_column, oci_cost.loc[:, c])
 
-                # Synthesized tag for account name
-                cbf_frame.insert(len(cbf_frame.columns), 'resource/tag:oci_tenancy_name', oci_cost.loc[:, 'lineItem/tenantId'])
-                cbf_frame['resource/tag:oci_tenancy_name'] = cbf_frame['resource/tag:oci_tenancy_name'].map(lambda t:__tenancy_name_lookup(t, oci_config))
+                # Synthesized Tags
+                # Tenancy Name
+                cbf_frame.insert(
+                    len(cbf_frame.columns), 
+                    'resource/tag:oci_tenancy_name',
+                    oci_cost.loc[:, 'lineItem/tenantId']
+                )
+                cbf_frame['resource/tag:oci_tenancy_name'] = cbf_frame['resource/tag:oci_tenancy_name'].map(
+                    lambda t:__tenancy_name_lookup(t, oci_config)
+                )
+                # Compartment Name
+                cbf_frame.insert(len(cbf_frame.columns),
+                                 "resource/tag:oci_compartment_name",
+                                 oci_cost.loc[:, "product/compartmentName"])
+                # Compartment ID
+                cbf_frame.insert(len(cbf_frame.columns),
+                                 "resource/tag:oci_compartment_id",
+                                 oci_cost.loc[:, "product/compartmentId"])
+                # Availability Domain
+                cbf_frame.insert(len(cbf_frame.columns),
+                                 "resource/tag:oci_availability_domain",
+                                 oci_cost.loc[:, "product/availabilityDomain"])
+
 
                 # This section prunes the CBF frames to contain only rows with
                 # usage_start dates within the BDID boundary.
@@ -200,7 +226,7 @@ def build_anycost_drop_from_oci_files(lookback_months: int,
                 cbf_frame['time/usage_end']   = pandas.to_datetime(cbf_frame['time/usage_end'], cache=True)
 
                 # Create new date-only timestamp columns so we can look at those for pruning
-                # note the .dt property refers to the datetime object inside the column 
+                # note the .dt property refers to the datetime object inside the column
                 cbf_frame['time/usage_start_date'] = cbf_frame['time/usage_start'].dt.date
                 cbf_frame['time/usage_end_date']   = cbf_frame['time/usage_end'].dt.date
 
@@ -209,10 +235,10 @@ def build_anycost_drop_from_oci_files(lookback_months: int,
                 # every row to see whether it belongs within the window.
                 if start_date: # conditional here since @start_date is inside the string
                     cbf_frame.query('`time/usage_start_date` >= @start_date', inplace=True)
-                
+
                 if end_date:
                     cbf_frame.query('`time/usage_start_date` <= @end_date', inplace=True)
-                
+
                 # Finally, let's drop the _date columns since they don't belong
                 # in the output.
                 cbf_frame.drop(columns=['time/usage_start_date', 'time/usage_end_date'], inplace=True)
@@ -228,7 +254,7 @@ def build_anycost_drop_from_oci_files(lookback_months: int,
                     print(f"No rows remaining after date window prune in file {cost_file}")
 
     # Emit manifest pointing at our current drop.
-    # There should only be 1, despite the for statement. 
+    # There should only be 1, despite the for statement.
     for d in drop_paths:
         manifest = {
             "version": "1.0.0",

--- a/python/cli.py
+++ b/python/cli.py
@@ -64,6 +64,7 @@ downloaded_reports = anycostoci.download_oci_cost_files(
 
 output_paths = anycostoci.build_anycost_drop_from_oci_files(
   args.lookback_months, 
+  oci_config,
   oci_cost_files_dir = oci_write_dir, 
   output_dir = anycost_drop_dir
 )

--- a/python/cli.py
+++ b/python/cli.py
@@ -37,8 +37,7 @@ args = parser.parse_args()
 
 print(f"Args given: {args}")
 
-# temp_dir = tempfile.TemporaryDirectory(dir=args.temp_dir)
-temp_dir = '/tmp/'
+temp_dir = args.temp_dir
 
 # Filesystem sanity check
 try:
@@ -58,14 +57,14 @@ oci_config = oci.config.from_file(oci_file, oci.config.DEFAULT_PROFILE)
 print(f"OCI Config: {oci_config}")
 
 downloaded_reports = anycostoci.download_oci_cost_files(
-                        args.lookback_months, 
+                        args.lookback_months,
                         oci_config = oci_config,
                         output_dir = oci_write_dir)
 
 output_paths = anycostoci.build_anycost_drop_from_oci_files(
-  args.lookback_months, 
+  args.lookback_months,
   oci_config,
-  oci_cost_files_dir = oci_write_dir, 
+  oci_cost_files_dir = oci_write_dir,
   output_dir = anycost_drop_dir
 )
 

--- a/python/lambda.py
+++ b/python/lambda.py
@@ -62,7 +62,8 @@ def anycost(event, context):
         )
 
         output_drops = anycostoci.build_anycost_drop_from_oci_files(
-            lookback_months = lookback_months,
+            lookback_months,
+            oci_config,
             oci_cost_files_dir = oci_write_dir,
             output_dir = anycost_drop_dir,
         )


### PR DESCRIPTION
### Description

Add the tenancy name of each resource to the CBF output files. It's added as a synthesized tag on the resource, at least for now, as CBF doesn't yield a standard account name field. An additional API call is required for each unique tenancy ID in the OCI cost file set, along with permissions necessary in Oracle for the API user to make the call (`TENANCY_INSPECT`).


### References

Fulfills #2 

### Testing

- [x] Verify that a new drop populates the tenant name on all rows.
- [x] Verify that CZ backfills this tag to old lineitems.

### Checklist

- [x] I have added documentation for new/changed functionality in this PR
- [ ] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `main`